### PR TITLE
WS2812: Verbesserungen am Breakout-Board

### DIFF
--- a/breakout-boards/breakout-ws2812.brd
+++ b/breakout-boards/breakout-ws2812.brd
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.005" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -56,16 +56,16 @@
 </layers>
 <board>
 <plain>
-<wire x1="0" y1="0" x2="20.32" y2="0" width="0" layer="20"/>
+<wire x1="-1.27" y1="0" x2="20.32" y2="0" width="0" layer="20"/>
 <wire x1="20.32" y1="0" x2="20.32" y2="13.97" width="0" layer="20"/>
-<wire x1="20.32" y1="13.97" x2="0" y2="13.97" width="0" layer="20"/>
-<wire x1="0" y1="13.97" x2="0" y2="0" width="0" layer="20"/>
+<wire x1="20.32" y1="13.97" x2="-1.27" y2="13.97" width="0" layer="20"/>
+<wire x1="-1.27" y1="13.97" x2="-1.27" y2="0" width="0" layer="20"/>
 <text x="14.605" y="11.049" size="1.016" layer="16" font="vector" ratio="15" rot="MR0">Netz39 e.V.</text>
 <text x="13.716" y="1.778" size="1.016" layer="16" font="vector" ratio="15" rot="MR0">CC-BY-SA</text>
 <text x="19.685" y="0.762" size="1.27" layer="16" font="vector" rot="MR0">+</text>
 <text x="19.685" y="12.065" size="1.27" layer="16" font="vector" rot="MR0">G</text>
-<text x="1.524" y="0.381" size="1.27" layer="16" font="vector" rot="MR0">O</text>
-<text x="1.143" y="12.192" size="1.27" layer="16" font="vector" rot="MR0">I</text>
+<text x="0.254" y="0.381" size="1.27" layer="16" font="vector" rot="MR0">O</text>
+<text x="-0.127" y="12.192" size="1.27" layer="16" font="vector" rot="MR0">I</text>
 </plain>
 <libraries>
 <library name="pinhead">
@@ -1406,17 +1406,17 @@ design rules under a new name.</description>
 <element name="R1" library="resistor" package="R1206" value="" x="15.24" y="5.715" rot="MR180"/>
 <element name="C1" library="resistor" package="C1206" value="" x="15.24" y="8.255" rot="MR180"/>
 <element name="JP3" library="pinhead" package="1X01" value="VDD" x="17.145" y="3.175"/>
-<element name="JP4" library="pinhead" package="1X01" value="DI" x="3.175" y="10.795"/>
+<element name="JP4" library="pinhead" package="1X01" value="DI" x="1.905" y="10.795"/>
 <element name="JGND" library="pinhead" package="1X01" value="GND" x="17.145" y="10.795"/>
-<element name="JDO" library="pinhead" package="1X01" value="DO" x="3.175" y="3.175"/>
+<element name="JDO" library="pinhead" package="1X01" value="DO" x="1.905" y="3.175"/>
 </elements>
 <signals>
 <signal name="GND">
 <polygon width="0.4064" layer="16">
-<vertex x="1.27" y="12.7"/>
+<vertex x="0" y="12.7"/>
 <vertex x="19.05" y="12.7"/>
 <vertex x="19.05" y="1.27"/>
-<vertex x="1.27" y="1.27"/>
+<vertex x="0" y="1.27"/>
 </polygon>
 <contactref element="C1" pad="2"/>
 <contactref element="U$1" pad="6"/>
@@ -1448,15 +1448,16 @@ design rules under a new name.</description>
 <signal name="JDI">
 <contactref element="U$1" pad="2"/>
 <contactref element="JP4" pad="1"/>
-<wire x1="3.175" y1="10.795" x2="3.175" y2="7.62" width="0.6096" layer="16"/>
-<wire x1="4.14" y1="6.655" x2="5.36" y2="6.655" width="0.6096" layer="16"/>
-<wire x1="3.175" y1="7.62" x2="4.14" y2="6.655" width="0.6096" layer="16"/>
+<wire x1="5.36" y1="6.655" x2="5.055" y2="6.35" width="0.4064" layer="16"/>
+<wire x1="1.905" y1="8.255" x2="1.905" y2="10.795" width="0.6096" layer="16"/>
+<wire x1="1.905" y1="8.255" x2="3.505" y2="6.655" width="0.6096" layer="16"/>
+<wire x1="3.505" y1="6.655" x2="5.36" y2="6.655" width="0.6096" layer="16"/>
 </signal>
 <signal name="N$2">
 <contactref element="U$1" pad="1"/>
 <contactref element="JDO" pad="1"/>
-<wire x1="3.175" y1="3.175" x2="5.055" y2="5.055" width="0.6096" layer="16"/>
-<wire x1="5.055" y1="5.055" x2="5.36" y2="5.055" width="0.4064" layer="16"/>
+<wire x1="1.905" y1="3.175" x2="3.785" y2="5.055" width="0.6096" layer="16"/>
+<wire x1="3.785" y1="5.055" x2="5.36" y2="5.055" width="0.6096" layer="16"/>
 </signal>
 </signals>
 <errors>


### PR DESCRIPTION
- Lötpads größer gemacht, damit sie nicht mehr abreißen
- Anschluss-Beschriftung

Hinweis: Am WS2812 wurde nichts geändert. Die Kupferbahn um die Lötaugen für die Pins sind breiter geworden. Ansonsten ist das Board schon gelötet und getest!
