### PR TITLE
SRKL

### DIFF
--- a/lib/n39.lbr
+++ b/lib/n39.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -668,7 +668,11 @@ Rastermaß 5,08 mm</description>
 <package name="SRKL">
 <description>&lt;h1&gt;SWITCH&lt;/h1&gt;
 
-&lt;p&gt;(Copied from &lt;em&gt;switch-misc&lt;/em&gt;.)&lt;/p&gt;</description>
+&lt;p&gt;(Copied from &lt;em&gt;switch-misc&lt;/em&gt;.)&lt;/p&gt;
+&lt;p&gt;Changes:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Rotated the switch pins to solve DRC overlap warnings.&lt;/li&gt;
+&lt;/ul&gt;</description>
 <wire x1="-6.223" y1="-8.763" x2="6.223" y2="-8.763" width="0.1524" layer="21"/>
 <wire x1="6.223" y1="8.763" x2="-6.223" y2="8.763" width="0.1524" layer="21"/>
 <wire x1="6.223" y1="-8.509" x2="-6.223" y2="-8.509" width="0.1524" layer="51"/>
@@ -691,10 +695,10 @@ Rastermaß 5,08 mm</description>
 <wire x1="-5.08" y1="-7.366" x2="-6.223" y2="-8.509" width="0.1524" layer="51"/>
 <circle x="0" y="5.08" radius="1.143" width="0.1524" layer="51"/>
 <circle x="0" y="5.08" radius="1.524" width="0.1524" layer="51"/>
-<pad name="2" x="-3.81" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="3" x="3.81" y="0" drill="0.8128" shape="long" rot="R90"/>
-<pad name="1" x="-3.81" y="-5.08" drill="0.8128" shape="long" rot="R90"/>
-<pad name="4" x="3.81" y="-5.08" drill="0.8128" shape="long" rot="R90"/>
+<pad name="2" x="-3.81" y="0" drill="0.8128" shape="long" rot="R180"/>
+<pad name="3" x="3.81" y="0" drill="0.8128" shape="long" rot="R180"/>
+<pad name="1" x="-3.81" y="-5.08" drill="0.8128" shape="long" rot="R180"/>
+<pad name="4" x="3.81" y="-5.08" drill="0.8128" shape="long" rot="R180"/>
 <pad name="+" x="-1.27" y="5.08" drill="0.8128" shape="long" rot="R90"/>
 <pad name="-" x="1.27" y="5.08" drill="0.8128" shape="long" rot="R90"/>
 <text x="-6.223" y="9.144" size="1.27" layer="25" ratio="10">&gt;NAME</text>


### PR DESCRIPTION
Copied the part SRKL from switch-misc and rotated the pins to solve DRC overlap warnings.

Affected 
- parts: SRKL
- packages: SRKL
- symbols: TSU1, KEY-LED
