### PR TITLE
WS2812: better symbol

### DIFF
--- a/lib/n39.lbr
+++ b/lib/n39.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.5" altunitdist="mm" altunit="mm"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -1267,9 +1267,9 @@ on the speed of signal transmission.&lt;/p&gt;
 <wire x1="-12.7" y1="-12.7" x2="-12.7" y2="12.7" width="0.254" layer="94"/>
 <pin name="DI" x="-17.78" y="-7.62" length="middle" direction="in"/>
 <pin name="DO" x="17.78" y="-7.62" length="middle" direction="out" rot="R180"/>
-<pin name="VCC" x="-17.78" y="7.62" length="middle" direction="pwr"/>
-<pin name="VDD" x="-17.78" y="2.54" length="middle" direction="pwr"/>
-<pin name="GND" x="17.78" y="7.62" length="middle" direction="pwr" rot="R180"/>
+<pin name="VCC" x="5.08" y="17.78" length="middle" direction="pwr" rot="R270"/>
+<pin name="VDD" x="-5.08" y="17.78" length="middle" direction="pwr" rot="R270"/>
+<pin name="GND" x="0" y="-17.78" length="middle" direction="pwr" rot="R90"/>
 <circle x="0" y="0" radius="3.5921" width="0.254" layer="94"/>
 <text x="-5.08" y="-10.16" size="1.778" layer="94">WS2812</text>
 </symbol>


### PR DESCRIPTION
Restructured the symbol so that chains can be easier modelled in the schematic.
